### PR TITLE
Fix callback for nested tags.

### DIFF
--- a/src/pacsanini/parse.py
+++ b/src/pacsanini/parse.py
@@ -51,7 +51,7 @@ def get_dicom_tag_value(
         if seq is None or seq.VM == 0:
             # ValueMultiplicity set to 0 indicates an invalid sequence.
             return None
-        return get_dicom_tag_value(seq[0], sub_tag)
+        return get_dicom_tag_value(seq[0], sub_tag, callback=callback)
 
     try:
         data_el = data.data_element(tag_name)

--- a/tests/parse_test.py
+++ b/tests/parse_test.py
@@ -58,6 +58,16 @@ def test_get_dicom_tag_value(dicom: pydicom.FileDataset):
     new_value = parse.get_dicom_tag_value(dicom, "NonExistent.Tag")
     assert new_value is None
 
+    # parse a nested tag without callback
+    new_value = parse.get_dicom_tag_value(dicom, "ViewCodeSequence.CodeValue")
+    assert new_value == "R-10226"
+
+    # parse a nested tag with callback
+    new_value = parse.get_dicom_tag_value(
+        dicom, "ViewCodeSequence.CodeValue", callback=rand_val
+    )
+    assert new_value == "foobar"
+
 
 @pytest.mark.parse
 def test_get_tag_value(dicom: pydicom.FileDataset):


### PR DESCRIPTION
# What this PR does
* Make sure the 'callback' argument is passed to recursive calls of 'get_dicom_tag_value()'
* Add unittest on nested tag (checking the value with/without the callback)

Fixes #35

## Submission checklist

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [ ] I have listed any additional dependencies that are needed for this change.