### PR TITLE
Include DICOM path in parsing by default.

### DIFF
--- a/src/pacsanini/cli/parse.py
+++ b/src/pacsanini/cli/parse.py
@@ -61,9 +61,11 @@ from pacsanini.parse import DicomTagGroup
     ),
 )
 @option(
-    "--include-path",
+    "--include-path/--exclude-path",
     cls=GroupOption,
     is_flag=True,
+    default=True,
+    show_default=True,
     help_group="Output Options",
     help="Include DICOM file paths in the output results.",
 )

--- a/src/pacsanini/io/base_parser.py
+++ b/src/pacsanini/io/base_parser.py
@@ -105,7 +105,7 @@ def parse_dir(
     nb_threads : int
         The number of threads to use for the parsing of DICOM files.
     include_path : bool
-        If True, add a "dicom_path" key to the results directory.
+        If True, the default, add a "dicom_path" key to the results directory.
     """
     if not os.path.exists(src):
         raise FileNotFoundError(f"'{src}' does not exist.")

--- a/src/pacsanini/io/df_parser.py
+++ b/src/pacsanini/io/df_parser.py
@@ -22,7 +22,7 @@ def parse_dir2df(
     src: Union[str, PathLike],
     parser: DicomTagGroup,
     nb_threads: int = 1,
-    include_path: bool = False,
+    include_path: bool = True,
 ) -> pd.DataFrame:
     """Parse a DICOM directory and return the parsed DICOM
     tag results as a DataFrame.
@@ -39,7 +39,7 @@ def parse_dir2df(
         files. The default is 1.
     include_path : bool
         If True, add a "dicom_path" key to the parsed results.
-        The default is False.
+        The default is True.
 
     Returns
     -------

--- a/src/pacsanini/io/io_parsers.py
+++ b/src/pacsanini/io/io_parsers.py
@@ -25,7 +25,7 @@ def parse_dir2csv(
     parser: DicomTagGroup,
     dest: Union[str, PathLike, TextIO],
     nb_threads: int = 1,
-    include_path: bool = False,
+    include_path: bool = True,
     mode: str = "w",
 ):
     """Parse a DICOM directory and write results to a CSV
@@ -45,7 +45,7 @@ def parse_dir2csv(
         files. The default is 1.
     include_path : bool
         If True, add a "dicom_path" key to the parsed results.
-        The default is False.
+        The default is True.
     mode : str
         Whether to write ("w") or append ("a") to the
         destination file.
@@ -99,7 +99,7 @@ def parse_dir2json(
     parser: DicomTagGroup,
     dest: Union[str, PathLike, TextIO],
     nb_threads: int = 1,
-    include_path: bool = False,
+    include_path: bool = True,
     mode: str = "w",
 ):
     """Parse a DICOM directory and write results to a JSON
@@ -119,7 +119,7 @@ def parse_dir2json(
         files. The default is 1.
     include_path : bool
         If True, add a "dicom_path" key to the parsed results.
-        The default is False.
+        The default is True.
     mode : str
         Whether to write ("w") or append ("a") to the
         destination file.

--- a/tests/cli/parse_test.py
+++ b/tests/cli/parse_test.py
@@ -33,6 +33,7 @@ def test_parse(data_dir):
     )
     assert result_csv.exit_code == 0
     assert len(result_csv.output) > 0
+    assert ",dicom_path" in result_csv.output
 
     result_json = runner.invoke(
         parse,
@@ -43,10 +44,12 @@ def test_parse(data_dir):
             os.path.join(data_dir, "tags_conf.json"),
             "--fmt",
             "json",
+            "--exclude-path",
         ],
     )
     assert result_json.exit_code == 0
     assert len(result_json.output) > 0
+    assert '"dicom_path"' not in result_json.output
 
     result_invalid = result_json = runner.invoke(
         parse,


### PR DESCRIPTION
Signed-off-by: Aurélien Chick <aurelien.chick@gmail.com>

# What this PR does

Fixes #37.

The resolution of this issue was quite straightforward. It turns out that `pacsanini.io.base_parser.parse_dir`'s `include_path` parameter was already set to True by default. In turn, the `parse_dir2csv`, `parse_dir2json`, and `parse_dir2df` methods had their `include_path` parameters set to True as well. This can therefore be seen as a way to standardize the parsing methods' behaviors. The docstrings were also updated. 

The `parse` sub-command was also updated so that the path is included by default as well. Tests for this were also updated.

## Submission checklist

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [ ] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
