### PR TITLE
Sql backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,4 @@ repos:
     rev: v0.910
     hooks:
     -   id: mypy
-        additional_dependencies: [types-click==7.1.2, types-PyYAML==5.4.3]
+        additional_dependencies: [types-click==7.1.2, types-PyYAML==5.4.3, 'sqlalchemy[mypy]']

--- a/LICENSES/SQLALCHEMY_LICENSE
+++ b/LICENSES/SQLALCHEMY_LICENSE
@@ -1,0 +1,19 @@
+Copyright 2005-2021 SQLAlchemy authors and contributors <see AUTHORS file>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/api_reference/db.md
+++ b/docs/api_reference/db.md
@@ -1,0 +1,3 @@
+::: pacsanini.db.crud
+
+::: pacsanini.db.parser

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - cli: 'api_reference/cli.md'
     - config: 'api_reference/config.md'
     - convert: 'api_reference/convert.md'
+    - db: 'api_reference/db.md'
     - errors: 'api_reference/errors.md'
     - io: 'api_reference/io.md'
     - models: 'api_reference/models.md'

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ warn_return_any = False
 warn_unreachable = True
 ignore_missing_imports = True
 strict_optional = False
+plugins = sqlalchemy.ext.mypy.plugin
 
 [mypy-luigi.*]
 ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -281,6 +281,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "greenlet"
+version = "1.1.0"
+description = "Lightweight in-process concurrent programming"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.extras]
+docs = ["sphinx"]
+
+[[package]]
 name = "identify"
 version = "1.5.12"
 description = "File identification library for Python"
@@ -295,7 +306,7 @@ license = ["editdistance"]
 name = "importlib-metadata"
 version = "3.4.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -709,7 +720,7 @@ pytkdocs = ">=0.2.0,<0.12.0"
 name = "mypy"
 version = "0.910"
 description = "Optional static typing for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -727,7 +738,7 @@ python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1345,6 +1356,52 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "sqlalchemy"
+version = "1.4.22"
+description = "Database Abstraction Library"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mypy = {version = ">=0.800", optional = true, markers = "python_version >= \"3\" and extra == \"mypy\""}
+sqlalchemy2-stubs = {version = "*", optional = true, markers = "extra == \"mypy\""}
+
+[package.extras]
+aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
+aiosqlite = ["greenlet (!=0.4.17)", "aiosqlite"]
+asyncio = ["greenlet (!=0.4.17)"]
+mariadb_connector = ["mariadb (>=1.0.1)"]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mypy = ["sqlalchemy2-stubs", "mypy (>=0.800)"]
+mysql = ["mysqlclient (>=1.4.0,<2)", "mysqlclient (>=1.4.0)"]
+mysql_connector = ["mysqlconnector"]
+oracle = ["cx_oracle (>=7,<8)", "cx_oracle (>=7)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql_asyncpg = ["greenlet (!=0.4.17)", "asyncpg"]
+postgresql_pg8000 = ["pg8000 (>=1.16.6)"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql (<1)", "pymysql"]
+sqlcipher = ["sqlcipher3-binary"]
+
+[[package]]
+name = "sqlalchemy2-stubs"
+version = "0.0.2a8"
+description = "Typing Stubs for SQLAlchemy 1.4"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mypy = ">=0.800"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "tenacity"
 version = "6.3.1"
 description = "Retry code until it succeeds"
@@ -1389,7 +1446,7 @@ test = ["pytest", "pathlib2"]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -1455,7 +1512,7 @@ test = ["pytest"]
 name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1541,7 +1598,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.4.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1552,7 +1609,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "8a3616c5ae617e30192d3a2922bf87da526b0a1d3fe61fcc8f687b8d18cdcd88"
+content-hash = "e6cb6d0e66211723ae454c7b4acd52168c722f5816e9fa6be886ea903cc8c059"
 
 [metadata.files]
 altgraph = [
@@ -1777,6 +1834,57 @@ flake8 = [
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+greenlet = [
+    {file = "greenlet-1.1.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:60848099b76467ef09b62b0f4512e7e6f0a2c977357a036de602b653667f5f4c"},
+    {file = "greenlet-1.1.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f42ad188466d946f1b3afc0a9e1a266ac8926461ee0786c06baac6bd71f8a6f3"},
+    {file = "greenlet-1.1.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:76ed710b4e953fc31c663b079d317c18f40235ba2e3d55f70ff80794f7b57922"},
+    {file = "greenlet-1.1.0-cp27-cp27m-win32.whl", hash = "sha256:b33b51ab057f8a20b497ffafdb1e79256db0c03ef4f5e3d52e7497200e11f821"},
+    {file = "greenlet-1.1.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed1377feed808c9c1139bdb6a61bcbf030c236dd288d6fca71ac26906ab03ba6"},
+    {file = "greenlet-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:da862b8f7de577bc421323714f63276acb2f759ab8c5e33335509f0b89e06b8f"},
+    {file = "greenlet-1.1.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5f75e7f237428755d00e7460239a2482fa7e3970db56c8935bd60da3f0733e56"},
+    {file = "greenlet-1.1.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:258f9612aba0d06785143ee1cbf2d7361801c95489c0bd10c69d163ec5254a16"},
+    {file = "greenlet-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d928e2e3c3906e0a29b43dc26d9b3d6e36921eee276786c4e7ad9ff5665c78a"},
+    {file = "greenlet-1.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cc407b68e0a874e7ece60f6639df46309376882152345508be94da608cc0b831"},
+    {file = "greenlet-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c557c809eeee215b87e8a7cbfb2d783fb5598a78342c29ade561440abae7d22"},
+    {file = "greenlet-1.1.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:3d13da093d44dee7535b91049e44dd2b5540c2a0e15df168404d3dd2626e0ec5"},
+    {file = "greenlet-1.1.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b3090631fecdf7e983d183d0fad7ea72cfb12fa9212461a9b708ff7907ffff47"},
+    {file = "greenlet-1.1.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:06ecb43b04480e6bafc45cb1b4b67c785e183ce12c079473359e04a709333b08"},
+    {file = "greenlet-1.1.0-cp35-cp35m-win32.whl", hash = "sha256:944fbdd540712d5377a8795c840a97ff71e7f3221d3fddc98769a15a87b36131"},
+    {file = "greenlet-1.1.0-cp35-cp35m-win_amd64.whl", hash = "sha256:c767458511a59f6f597bfb0032a1c82a52c29ae228c2c0a6865cfeaeaac4c5f5"},
+    {file = "greenlet-1.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2325123ff3a8ecc10ca76f062445efef13b6cf5a23389e2df3c02a4a527b89bc"},
+    {file = "greenlet-1.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:598bcfd841e0b1d88e32e6a5ea48348a2c726461b05ff057c1b8692be9443c6e"},
+    {file = "greenlet-1.1.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:be9768e56f92d1d7cd94185bab5856f3c5589a50d221c166cc2ad5eb134bd1dc"},
+    {file = "greenlet-1.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfe7eac0d253915116ed0cd160a15a88981a1d194c1ef151e862a5c7d2f853d3"},
+    {file = "greenlet-1.1.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a6b035aa2c5fcf3dbbf0e3a8a5bc75286fc2d4e6f9cfa738788b433ec894919"},
+    {file = "greenlet-1.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca1c4a569232c063615f9e70ff9a1e2fee8c66a6fb5caf0f5e8b21a396deec3e"},
+    {file = "greenlet-1.1.0-cp36-cp36m-win32.whl", hash = "sha256:3096286a6072553b5dbd5efbefc22297e9d06a05ac14ba017233fedaed7584a8"},
+    {file = "greenlet-1.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:c35872b2916ab5a240d52a94314c963476c989814ba9b519bc842e5b61b464bb"},
+    {file = "greenlet-1.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b97c9a144bbeec7039cca44df117efcbeed7209543f5695201cacf05ba3b5857"},
+    {file = "greenlet-1.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:16183fa53bc1a037c38d75fdc59d6208181fa28024a12a7f64bb0884434c91ea"},
+    {file = "greenlet-1.1.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6b1d08f2e7f2048d77343279c4d4faa7aef168b3e36039cba1917fffb781a8ed"},
+    {file = "greenlet-1.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14927b15c953f8f2d2a8dffa224aa78d7759ef95284d4c39e1745cf36e8cdd2c"},
+    {file = "greenlet-1.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bdcff4b9051fb1aa4bba4fceff6a5f770c6be436408efd99b76fc827f2a9319"},
+    {file = "greenlet-1.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70c7dd733a4c56838d1f1781e769081a25fade879510c5b5f0df76956abfa05"},
+    {file = "greenlet-1.1.0-cp37-cp37m-win32.whl", hash = "sha256:0de64d419b1cb1bfd4ea544bedea4b535ef3ae1e150b0f2609da14bbf48a4a5f"},
+    {file = "greenlet-1.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8833e27949ea32d27f7e96930fa29404dd4f2feb13cce483daf52e8842ec246a"},
+    {file = "greenlet-1.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:c1580087ab493c6b43e66f2bdd165d9e3c1e86ef83f6c2c44a29f2869d2c5bd5"},
+    {file = "greenlet-1.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ad80bb338cf9f8129c049837a42a43451fc7c8b57ad56f8e6d32e7697b115505"},
+    {file = "greenlet-1.1.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a9017ff5fc2522e45562882ff481128631bf35da444775bc2776ac5c61d8bcae"},
+    {file = "greenlet-1.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7920e3eccd26b7f4c661b746002f5ec5f0928076bd738d38d894bb359ce51927"},
+    {file = "greenlet-1.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:408071b64e52192869129a205e5b463abda36eff0cebb19d6e63369440e4dc99"},
+    {file = "greenlet-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be13a18cec649ebaab835dff269e914679ef329204704869f2f167b2c163a9da"},
+    {file = "greenlet-1.1.0-cp38-cp38-win32.whl", hash = "sha256:22002259e5b7828b05600a762579fa2f8b33373ad95a0ee57b4d6109d0e589ad"},
+    {file = "greenlet-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:206295d270f702bc27dbdbd7651e8ebe42d319139e0d90217b2074309a200da8"},
+    {file = "greenlet-1.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:096cb0217d1505826ba3d723e8981096f2622cde1eb91af9ed89a17c10aa1f3e"},
+    {file = "greenlet-1.1.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:03f28a5ea20201e70ab70518d151116ce939b412961c33827519ce620957d44c"},
+    {file = "greenlet-1.1.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:7db68f15486d412b8e2cfcd584bf3b3a000911d25779d081cbbae76d71bd1a7e"},
+    {file = "greenlet-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70bd1bb271e9429e2793902dfd194b653221904a07cbf207c3139e2672d17959"},
+    {file = "greenlet-1.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f92731609d6625e1cc26ff5757db4d32b6b810d2a3363b0ff94ff573e5901f6f"},
+    {file = "greenlet-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06d7ac89e6094a0a8f8dc46aa61898e9e1aec79b0f8b47b2400dd51a44dbc832"},
+    {file = "greenlet-1.1.0-cp39-cp39-win32.whl", hash = "sha256:adb94a28225005890d4cf73648b5131e885c7b4b17bc762779f061844aabcc11"},
+    {file = "greenlet-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:aa4230234d02e6f32f189fd40b59d5a968fe77e80f59c9c933384fe8ba535535"},
+    {file = "greenlet-1.1.0.tar.gz", hash = "sha256:c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee"},
 ]
 identify = [
     {file = "identify-1.5.12-py2.py3-none-any.whl", hash = "sha256:18994e850ba50c37bcaed4832be8b354d6a06c8fb31f54e0e7ece76d32f69bc8"},
@@ -2346,6 +2454,42 @@ send2trash = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+sqlalchemy = [
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win32.whl", hash = "sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win_amd64.whl", hash = "sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win32.whl", hash = "sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win_amd64.whl", hash = "sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win32.whl", hash = "sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win_amd64.whl", hash = "sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win32.whl", hash = "sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win_amd64.whl", hash = "sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win32.whl", hash = "sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win_amd64.whl", hash = "sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9"},
+    {file = "SQLAlchemy-1.4.22.tar.gz", hash = "sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8"},
+]
+sqlalchemy2-stubs = [
+    {file = "sqlalchemy2-stubs-0.0.2a8.tar.gz", hash = "sha256:dba91d8100b2b3c48e840fce0b2541f8e250045e7d81b4563e95de48ffe655b2"},
+    {file = "sqlalchemy2_stubs-0.0.2a8-py3-none-any.whl", hash = "sha256:c1f31bc2faa36a9d61260dcc8811a66e01293bedc51b8c34a46daf1e2a12b735"},
 ]
 tenacity = [
     {file = "tenacity-6.3.1-py2.py3-none-any.whl", hash = "sha256:baed357d9f35ec64264d8a4bbf004c35058fad8795c5b0d8a7dc77ecdcbb8f39"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ exclude = '''
 )
 '''
 
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "def __repr__", "if __name__ == .__main__.:"]
+
 [tool.isort]
 profile = "black"
 src_paths = ["src/pacsanini"]
@@ -70,6 +73,7 @@ pandas = "^1.2.4"
 pynetdicom = "^1.5.7"
 loguru = "^0.5.3"
 luigi = "^3.0.3"
+SQLAlchemy = {extras = ["mypy"], version = "^1.4.22"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"
@@ -202,9 +206,11 @@ markers = [
   "cli",
   "config",
   "convert",
+  "db",
   "io",
   "net",
-  "parse"
+  "parse",
+  "utils",
 ]
 minversion = "6.0"
 testpaths = ["tests"]

--- a/src/pacsanini/db/__init__.py
+++ b/src/pacsanini/db/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""The db module exposes classes and methods that are useful for linking
+DICOM data to databases.
+"""
+from pacsanini.db.crud import DBWrapper, add_found_study, add_image
+from pacsanini.db.models import Base, Images, StudyFind
+from pacsanini.db.parser import parse_dir2sql

--- a/src/pacsanini/db/crud.py
+++ b/src/pacsanini/db/crud.py
@@ -60,6 +60,8 @@ def add_found_study(dcm: Dataset, session: Session) -> None:
             value = elem.value
             if elem.VR == "PN":
                 value = str(value)
+            elif attr == "StudyDate":
+                value = convert.str2datetime(value)  # type: ignore
 
         setattr(db_study, alias, value)
 
@@ -135,7 +137,8 @@ def add_image(
 class DBWrapper:
     """A wrapper class for the database connections. The purpose of this is
     to be able to open database connections lazily inside a thread that may
-    not be the application's main thread.
+    not be the application's main thread. It is recommended to use instances
+    of this class inside a context manager.
 
     Attributes
     ----------

--- a/src/pacsanini/db/crud.py
+++ b/src/pacsanini/db/crud.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""The crud module provides methods and classes that can be used to insert
+single items (studies found from C-FIND requests or DICOM metadata) into a
+given database.
+"""
+from functools import lru_cache
+
+from loguru import logger
+from pydicom import Dataset
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from pacsanini import convert
+from pacsanini.db.models import Base, Images, StudyFind
+
+
+TAG_MAPPING = {
+    "patient_name": "PatientName",
+    "patient_id": "PatientID",
+    "study_uid": "StudyInstanceUID",
+    "study_date": "StudyDate",
+    "accession_number": "AccessionNumber",
+    "series_uid": "SeriesInstanceUID",
+    "modality": "Modality",
+    "sop_class_uid": "SOPClassUID",
+    "image_uid": "SOPInstanceUID",
+    "manufacturer": "Manufacturer",
+}
+
+
+def add_found_study(dcm: Dataset, session: Session) -> None:
+    """Add study metadata to the database after a successfull C-FIND
+    operation.
+
+    Parameters
+    ----------
+    dcm : Dataset
+        The retrieved Dataset instance resulting from a C-FIND operation.
+    session : Session
+        The database session.
+    """
+    fields = [
+        ("PatientName", "patient_name"),
+        ("PatientID", "patient_id"),
+        ("StudyInstanceUID", "study_uid"),
+        ("StudyDate", "study_date"),
+        ("AccessionNumber", "accession_number"),
+    ]
+
+    db_study = StudyFind()
+    for (attr, alias) in fields:
+        if attr not in dcm:
+            value = None
+        else:
+            elem = dcm[attr]
+            value = elem.value
+            if elem.VR == "PN":
+                value = str(value)
+
+        setattr(db_study, alias, value)
+
+    session.add(db_study)
+    session.commit()
+
+
+def add_image(
+    dcm: Dataset, session: Session, institution_name: str = None, filepath: str = None
+):
+    """Add image metadata to the database. If the image's StudyInstanceUID's value
+    can be found in the `studies_find` table, the image will be linked to it by
+    populating the study_find_id field.
+
+    Parameters
+    ----------
+    dcm : Dataset
+        The DICOM instance to add to the database.
+    session : Session
+        The database session to use.
+    institution_name : str
+        The name of the institution to associate the image with.
+    filepath : str
+        If set, fill in the filepath value for the new DICOM record.
+    """
+    result = (
+        session.query(Images).filter(Images.image_uid == dcm.SOPInstanceUID).first()
+    )
+    if result:
+        logger.warning(
+            f"{dcm.SOPInstanceUID} already exists in the database. Skipping new insert."
+        )
+        return
+
+    db_image = Images()
+
+    for column in Images.__table__.columns:
+        col_name = column.name
+        if col_name not in TAG_MAPPING:
+            continue
+        alias = col_name
+        attr = TAG_MAPPING[alias]
+
+        if attr not in dcm:
+            value = None
+        else:
+            elem = dcm[attr]
+            if elem.VR == "PN":
+                value = str(elem.value)
+            elif attr == "StudyDate":
+                value = convert.str2datetime(elem.value)  # type: ignore
+            else:
+                value = elem.value
+        setattr(db_image, alias, value)
+
+    db_image.meta = convert.dcm2dict(dcm, include_pixels=False)
+    db_image.institution_name = institution_name
+
+    result = (
+        session.query(StudyFind)
+        .filter(StudyFind.study_uid == dcm.StudyInstanceUID)
+        .first()
+    )
+    if result:
+        db_image.study_find_id = result.id
+    if filepath:
+        db_image.filepath = filepath
+
+    session.add(db_image)
+    session.commit()
+
+
+class DBWrapper:
+    """A wrapper class for the database connections. The purpose of this is
+    to be able to open database connections lazily inside a thread that may
+    not be the application's main thread.
+
+    Attributes
+    ----------
+    conn_uri : str
+        The database connection URI.
+    create_tables : bool
+        Whether to create tables when the connection is first established.
+        The default is False.
+    debug : bool
+        If True, echo SQL statements to the standard output. The default
+        is False.
+    """
+
+    def __init__(self, conn_uri: str, create_tables: bool = False, debug: bool = False):
+        self.conn_uri = conn_uri
+        self.create_tables = create_tables
+        self.debug = debug
+        self.engine: Engine = None
+        self.session: Session = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @lru_cache
+    def conn(self) -> Session:
+        """Obtain a session instance"""
+        self.engine = create_engine(self.conn_uri)
+        if self.create_tables:
+            Base.metadata.create_all(bind=self.engine, checkfirst=True)
+        Session = sessionmaker(bind=self.engine)
+        self.session = Session()
+        return self.session
+
+    def close(self):
+        """Close the instance's current session and engine if they are still open."""
+        if self.session is not None:
+            self.session.close()
+        if self.engine is not None:
+            self.engine.dispose()

--- a/src/pacsanini/db/crud.py
+++ b/src/pacsanini/db/crud.py
@@ -165,14 +165,14 @@ class DBWrapper:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    @lru_cache
+    @lru_cache(maxsize=1)
     def conn(self) -> Session:
         """Obtain a session instance"""
         self.engine = create_engine(self.conn_uri)
         if self.create_tables:
             Base.metadata.create_all(bind=self.engine, checkfirst=True)
-        Session = sessionmaker(bind=self.engine)
-        self.session = Session()
+        Session_ = sessionmaker(bind=self.engine)
+        self.session = Session_()
         return self.session
 
     def close(self):

--- a/src/pacsanini/db/models.py
+++ b/src/pacsanini/db/models.py
@@ -6,6 +6,7 @@
 in a SQL database.
 """
 from datetime import datetime
+from typing import List
 
 from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import declarative_base, relationship
@@ -35,6 +36,17 @@ class StudyFind(Base):
     def __repr__(self):
         study_date = self.study_date.strftime("%Y%m%d")
         return f"<StudyFind: pid={self.patient_id}, pn={self.patient_name}, sd={study_date}>"
+
+    @classmethod
+    def cfind_fields(cls) -> List[str]:
+        """Returns the fields names that can be used for C-FIND queries."""
+        return [
+            "PatientName",
+            "PatientID",
+            "StudyInstanceUID",
+            "StudyDate",
+            "AccessionNumber",
+        ]
 
 
 class Images(Base):

--- a/src/pacsanini/db/models.py
+++ b/src/pacsanini/db/models.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""The models module provides classes that are used to represent DICOM data
+in a SQL database.
+"""
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+
+Base = declarative_base()
+
+
+class StudyFind(Base):
+    """Table corresponding to the studies that were found using
+    C-FIND operations.
+    """
+
+    __tablename__ = "studies_find"
+
+    id = Column(Integer, primary_key=True)
+    patient_name = Column(String)
+    patient_id = Column(String)
+    study_uid = Column(String, index=True, unique=True)
+    study_date = Column(DateTime)
+    accession_number = Column(String)
+    retrieved = Column(Boolean, default=False)
+    found_on = Column(DateTime, default=datetime.utcnow)
+
+    images: "Images" = relationship("Images", back_populates="study_find")
+
+    def __repr__(self):
+        study_date = self.study_date.strftime("%Y%m%d")
+        return f"<StudyFind: pid={self.patient_id}, pn={self.patient_name}, sd={study_date}>"
+
+
+class Images(Base):
+    """Table corresponding to the studies that were queried and
+    retrieved from the PACS.
+    """
+
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True)
+    study_find_id = Column(Integer, ForeignKey("studies_find.id"), nullable=True)
+    institution_name = Column(String)
+    patient_id = Column(String)
+    patient_name = Column(String)
+    study_uid = Column(String)
+    study_date = Column(DateTime)
+    series_uid = Column(String)
+    modality = Column(String)
+    sop_class_uid = Column(String)
+    image_uid = Column(String, index=True)
+    manufacturer = Column(String)
+    meta = Column(JSON, nullable=True)
+    filepath = Column(String, nullable=True)
+
+    study_find: "StudyFind" = relationship("StudyFind", back_populates="images")
+
+    def __repr__(self):
+        study_date = (
+            self.study_date.strftime("%Y%m%d") if self.study_date is not None else None
+        )
+        return f"<Image: pid={self.patient_id}, sd={study_date}, iuid={self.image_uid}>"

--- a/src/pacsanini/db/parser.py
+++ b/src/pacsanini/db/parser.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""The parser module module provides convenience methods for parsing DICOM files
+and storing results into a given database.
+"""
+from datetime import datetime
+
+from pacsanini.db.crud import DBWrapper, add_image
+from pacsanini.io.base_parser import parse_dir
+
+
+def _inner_sql(result: dict, db_wrapper: DBWrapper, institution_name: str):
+    dcm = result.pop("dicom")
+    add_image(
+        dcm,
+        db_wrapper.conn(),
+        institution_name=institution_name,
+        filepath=result["dicom_path"],
+    )
+
+
+def parse_dir2sql(
+    src: str, conn_uri: str, institution_name: str = None, nb_threads: int = 1
+):
+    """Parse a DICOM directory and persist the found results in the database
+    specified by the conn_uri parameter.
+
+    Notes
+    -----
+    Unlike other parse_dir wrapper methods, this method does not use the DICOMTagParser
+    instance. Parsed DICOM files will have basic DICOM tag metadata stored in traditional
+    columns as well as the entire DICOM file (pixel data excluded) stored in JSON format.
+
+    Parameters
+    ----------
+    src : str
+        The DICOM directory to parse.
+    conn_uri : str
+        The database's connection URI to use.
+    institution_name : str
+        If specified, associate the parsed DICOM files with the name of an
+        institution. If unset, this will default to unknwon followed by today's
+        date in the YYYYMMDD format.
+    nb_threads : int
+        The number of threads to use. This defaults to 1.
+    """
+    if institution_name is None:
+        institution_name = f"unknown_{datetime.now().strftime('%Y%m%d')}"
+
+    with DBWrapper(conn_uri, create_tables=True, debug=True) as wrapper:
+        parse_dir(
+            src,
+            None,
+            _inner_sql,
+            nb_threads=nb_threads,
+            callback_args=(wrapper, institution_name),
+            include_path=True,
+        )

--- a/src/pacsanini/net/__init__.py
+++ b/src/pacsanini/net/__init__.py
@@ -10,8 +10,10 @@ from pacsanini.net.c_find import (
     find,
     patient_find,
     patient_find2csv,
+    patient_find2sql,
     study_find,
     study_find2csv,
+    study_find2sql,
 )
 from pacsanini.net.c_move import move, move_patients, move_studies
 from pacsanini.net.storescp import StoreSCPServer, run_server

--- a/tests/data/sqlparse_conf.yaml
+++ b/tests/data/sqlparse_conf.yaml
@@ -1,0 +1,4 @@
+storage:
+  resources: "sqlite:///test_parsedb.sqlite"
+  resources_meta: "foobar.csv"
+  directory: "directory"

--- a/tests/data/test_conf.yaml
+++ b/tests/data/test_conf.yaml
@@ -1,17 +1,17 @@
 net:
   called_node:
-    aetitle: dcmpy
-    ip: localhost
-    port: 11112
-  dest_node:
     aetitle: dicomserver
     ip: www.dicomserver.co.uk
+    port: 11112
+  dest_node:
+    aetitle: dcmpy
+    ip: localhost
     port: 104
   local_node:
     aetitle: dcmpy
     ip: localhost
     port: 104
-search:
+find:
   end_date: "20210606"
   modality: ''
   query_level: PATIENT

--- a/tests/db/__init__.py
+++ b/tests/db/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""Declare fixtures for the db testing module."""
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def sqlite_db_path(tmpdir: str) -> str:
+    """A temp path for the sqlite database."""
+    path = os.path.join(str(tmpdir), "test.db")
+    path = f"sqlite:///{path}"
+    return path

--- a/tests/db/parser_test.py
+++ b/tests/db/parser_test.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""Test that parsing DICOM files works with a SQL backend."""
+import os
+
+from typing import List
+
+import pytest
+
+from pydicom import FileDataset
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from pacsanini.db.models import Images
+from pacsanini.db.parser import parse_dir2sql
+
+
+@pytest.mark.db
+def test_parse_sql2db(data_dir: str, sqlite_db_path: str, dicom: FileDataset):
+    """Test that parsing DICOM data and persisting it into the
+    database works well.
+    """
+    parse_dir2sql(data_dir, sqlite_db_path, institution_name="foobar")
+
+    engine = create_engine(sqlite_db_path)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    results: List[Images] = session.query(Images).all()
+    assert len(results) > 1
+    for result in results:
+        assert os.path.exists(result.filepath)
+        assert result.institution_name == "foobar"
+
+    res: Images = (
+        session.query(Images).filter(Images.image_uid == dicom.SOPInstanceUID).first()
+    )
+    assert res

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -4,9 +4,9 @@ if they have the good columns.
 import pandas as pd
 import pytest
 
+from pacsanini import utils
 from pacsanini.errors import InvalidResourceFile
 from pacsanini.models import QueryLevel
-from pacsanini import utils
 
 
 @pytest.mark.utils


### PR DESCRIPTION
# What this PR does

Fixes #40. In this PR, I provide the foundations for pacsanini to have a SQL backend. Overall, I have implemented all what was set out in #40 except for the C-MOVE part. This is because the integration of a SQL backend would necessitate the Storescp server to support plugins/callbacks (see #8 ). Once this is possible, I will create an issue that will have the C-MOVE operations be compatible with the C-MOVE backend.

SQLAlchemy is now a new dependency of the project. I have also added their license in the LICENSES folder.

## Submission checklist

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [x] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
