### PR TITLE
Linked storescp to database app. see #48

### DIFF
--- a/src/pacsanini/cli/utils.py
+++ b/src/pacsanini/cli/utils.py
@@ -1,0 +1,24 @@
+"""Utility methods to facilitate usage of the pacsanini tool from the
+command line.
+"""
+import re
+
+
+SUPPORTED_DB_DIALECTS = [
+    re.compile(r"postgresql(\+[\w\d]+)?://"),
+    re.compile(r"mysql(\+[\w\d]+)?://"),
+    re.compile(r"mariadb(\+[\w\d]+)?://"),
+    re.compile(r"oracle(\+[\w\d]+)?://"),
+    re.compile(r"sqlite://"),
+]
+
+
+def is_db_uri(uri: str) -> bool:
+    """Return true if the URI is for a known database. False
+    otherwise (eg: it is a file path).
+    """
+    uri_lower = uri.lower()
+    for dialect in SUPPORTED_DB_DIALECTS:
+        if dialect.match(uri_lower):
+            return True
+    return False

--- a/src/pacsanini/db/__init__.py
+++ b/src/pacsanini/db/__init__.py
@@ -5,6 +5,13 @@
 """The db module exposes classes and methods that are useful for linking
 DICOM data to databases.
 """
-from pacsanini.db.crud import DBWrapper, add_found_study, add_image
+from pacsanini.db.crud import (
+    DBWrapper,
+    add_found_study,
+    add_image,
+    get_studies_to_move,
+    get_study_uids_to_move,
+    update_retrieved_study,
+)
 from pacsanini.db.models import Base, Images, Patients, Series, Studies, StudyFind
 from pacsanini.db.parser import parse_dir2sql

--- a/src/pacsanini/db/models.py
+++ b/src/pacsanini/db/models.py
@@ -8,16 +8,7 @@ in a SQL database.
 from datetime import datetime
 from typing import List
 
-from sqlalchemy import (
-    JSON,
-    Boolean,
-    Column,
-    DateTime,
-    Float,
-    ForeignKey,
-    Integer,
-    String,
-)
+from sqlalchemy import JSON, Column, DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import declarative_base, relationship
 
 
@@ -37,7 +28,7 @@ class StudyFind(Base):
     study_uid = Column(String, index=True, unique=True)
     study_date = Column(DateTime)
     accession_number = Column(String)
-    retrieved = Column(Boolean, default=False)
+    retrieved_on = Column(DateTime, default=None)
     found_on = Column(DateTime, default=datetime.utcnow)
 
     study: "Studies" = relationship("Studies", back_populates="study_find")

--- a/tests/cli/utils_test.py
+++ b/tests/cli/utils_test.py
@@ -1,0 +1,24 @@
+"""Test that CLI utilities function correctly."""
+import pytest
+
+from pacsanini.cli import utils
+
+
+@pytest.mark.cli
+def test_is_db_uri():
+    """Test that database URIs are correctly picked up."""
+    db_uris = [
+        "postgresql://foo:bar@localhost/mydatabase",
+        "postgresql+psycopg2://foo:bar@localhost/mydatabase",
+        "postgresql+pg8000://foo:bar@localhost/mydatabase",
+        "mysql://foo:bar@localhost/foo",
+        "mysql+mysqldb://foo:bar@localhost/foo",
+        "oracle://foo:bar@127.0.0.1:1521/mydb",
+        "sqlite:///foo.db",
+    ]
+    for uri in db_uris:
+        assert utils.is_db_uri(uri) is True
+
+    non_db_uris = ["/data/foo/bar.json", "sqlite.csv"]
+    for uri in non_db_uris:
+        assert utils.is_db_uri(uri) is False

--- a/tests/db/crud_test.py
+++ b/tests/db/crud_test.py
@@ -1,23 +1,55 @@
 """Test that CRUD methods function correctly."""
+from datetime import datetime, timedelta
+from typing import Tuple
+
 import pytest
 
 from pydicom import FileDataset
 from sqlalchemy.orm import Session
 
-from pacsanini.db.crud import add_found_study, add_image
+from pacsanini.db import crud
 from pacsanini.db.models import Images, StudyFind
+
+
+@pytest.fixture
+def add_studies_to_find(sqlite_session: Session):
+    """Add studies in the database that need to be found."""
+    study1 = StudyFind(
+        patient_name="patient1",
+        study_uid="study1",
+        study_date=datetime.now(),
+        accession_number="accession1",
+    )
+    study2 = StudyFind(
+        patient_name="patient1",
+        study_uid="study2",
+        study_date=datetime.now(),
+        accession_number="accession2",
+        found_on=datetime.utcnow(),
+        retrieved_on=datetime.utcnow(),
+    )
+
+    sqlite_session.add(study1)
+    sqlite_session.add(study2)
+    sqlite_session.commit()
+
+    yield study1, study2
+
+    sqlite_session.delete(study1)
+    sqlite_session.delete(study2)
+    sqlite_session.commit()
 
 
 @pytest.mark.db
 def test_add_image(dicom: FileDataset, sqlite_session: Session):
     """Test that adding an image to the database works well."""
-    image1 = add_image(sqlite_session, dicom)
+    image1 = crud.add_image(sqlite_session, dicom)
     assert isinstance(image1, Images)
     assert image1.image_uid == dicom.SOPInstanceUID
 
     assert len(sqlite_session.query(Images).all()) == 1
 
-    image2 = add_image(sqlite_session, dicom)
+    image2 = crud.add_image(sqlite_session, dicom)
     assert image2 is None
 
     assert len(sqlite_session.query(Images).all()) == 1
@@ -29,13 +61,53 @@ def test_add_found_study(dicom: FileDataset, sqlite_session: Session):
     well.
     """
     dcm_finding = dicom
-    study_finding1 = add_found_study(sqlite_session, dcm_finding)
+    study_finding1 = crud.add_found_study(sqlite_session, dcm_finding)
     assert isinstance(study_finding1, StudyFind)
     assert study_finding1.study_uid == dcm_finding.StudyInstanceUID
 
     assert len(sqlite_session.query(StudyFind).all()) == 1
 
-    study_finding2 = add_found_study(sqlite_session, dcm_finding)
+    study_finding2 = crud.add_found_study(sqlite_session, dcm_finding)
     assert study_finding2 is None
 
     assert len(sqlite_session.query(StudyFind).all()) == 1
+
+
+@pytest.mark.db
+def test_update_study(
+    add_studies_to_find: Tuple[StudyFind, StudyFind], sqlite_session: Session
+):
+    """Test that studies in the studies_find table are correctly updated."""
+    _, study_to_update = add_studies_to_find
+
+    before = datetime.utcnow()
+    updated_study = crud.update_retrieved_study(
+        sqlite_session, study_to_update.study_uid
+    )
+
+    assert updated_study is not None and isinstance(updated_study, StudyFind)
+    assert updated_study.study_uid == study_to_update.study_uid
+    assert (
+        before - timedelta(seconds=1)
+        < updated_study.retrieved_on
+        < before + timedelta(seconds=1)
+    )
+
+
+@pytest.mark.db
+def test_get_studies_to_retrieve(
+    add_studies_to_find: Tuple[StudyFind, StudyFind], sqlite_session: Session
+):
+    """Test that only studies that have not yet been retrieved are
+    returned.
+    """
+    studies_to_find = crud.get_studies_to_move(sqlite_session)
+    assert len(studies_to_find) == 1
+
+    expected_study, _ = add_studies_to_find
+    found_study = studies_to_find[0]
+    assert found_study.study_uid == expected_study.study_uid
+
+    study_uids_to_find = crud.get_study_uids_to_move(sqlite_session)
+    assert len(studies_to_find) == 1
+    assert study_uids_to_find[0] == expected_study.study_uid


### PR DESCRIPTION
Signed-off-by: Aurélien Chick <aurelien.chick@gmail.com>

# What this PR does

Fixes #48.

In this PR, the following issues have been addressed:

* The StudyFind model's retrieved_on field is now a datetime field instead of a boolean one.
* The C-FIND module now fully supports storing results in the database.
* The C-MOVE module's methods now accept a database session that can be passed on to the StoreSCP server. In turn, the server will use the session to add received data to the patients, studies, series, and images tables + update the studies_find table.
* These capabilities are also exposed for the command line tool

Note that the testing was done locally and using an Orthanc instance to test C-FIND and C-MOVE operations.
A potential follow-up could be to add an Orthanc Dockerfile somewhere that can be used to help/standardize local development.

## Submission checklist

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [x] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
