### PR TITLE
Include prefect config in pacsanini build. see #73

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:  ## Build the package, as a tarball and a wheel.
 	poetry build
 
 build-exe:  ## Build the package, as an executable (using pyinstaller). Don't do inside a virtualenv.
-	pyinstaller -n pacsanini src/pacsanini/__main__.py
+	python -O scripts/build-exe.py
 
 clean: clean-build clean-docs clean-tests clean-pyc  ## Clean up all types of project builds.
 

--- a/scripts/build-exe.py
+++ b/scripts/build-exe.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""Simple script to build the pacsanini executable."""
+import inspect
+import os
+
+import prefect
+import PyInstaller.__main__
+
+
+if __name__ == "__main__":
+    prefect_dir = os.path.dirname(inspect.getsourcefile(prefect))
+    prefect_config = os.path.join(prefect_dir, "config.toml")
+    PyInstaller.__main__.run(
+        [
+            "-n",
+            "pacsanini",
+            "--add-data",
+            f"{prefect_config}:prefect",
+            "src/pacsanini/__main__.py",
+        ]
+    )


### PR DESCRIPTION
The prefect configuration file is now added to the build output. In addition, I added the -O flag to python when calling PyInstaller.

# What this PR does

Fixes #73 

## Submission checklist

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] I have updated the documentation.
- [ ] I have updated relevant tests, if applicable.
- [ ] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
