### PR TITLE
Configured the pacsanini CLI option load order. see #71

### DIFF
--- a/docs/cli_reference/index.md
+++ b/docs/cli_reference/index.md
@@ -2,8 +2,13 @@
 
 !!! note
     This regards all pacsanini sub-commands that have an optional `-f/--config` option.
-    If unset, `pacsanini` will search for a file path specified by the `PACSANINI_CONFIG`
-    environment variable or a file in your home directory named `pacsaninirc.yaml`.
+    If unset, `pacsanini` will search for the following files in the provided order:
+
+    1. A file specified by the `PACSANINI_CONFIG` environment variable;
+    2. A file named `pacsaninirc.yaml` in your current directory.
+    3. A file named `pacsaninirc.yaml` in your home directory.
+
+    If none of these options correspond to an existing file and the `-f/--config` option is unset, an error will be raised.
 
 !!! note
     Refer to the [command configuration](../user_guide/configuration.md#command-configuration)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ minversion = "6.0"
 testpaths = ["tests"]
 filterwarnings = [
   'ignore:Starting in pydicom 3.0, Dataset.file_meta must be a FileMetaDataset class instance',
+  "ignore:Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0."
 ]
 
 [build-system]

--- a/src/pacsanini/cli/db.py
+++ b/src/pacsanini/cli/db.py
@@ -9,6 +9,7 @@ import click
 
 from sqlalchemy import create_engine
 
+from pacsanini.cli.base import config_option
 from pacsanini.config import PacsaniniConfig
 from pacsanini.db.utils import (
     TABLES,
@@ -16,19 +17,10 @@ from pacsanini.db.utils import (
     get_db_session,
     initialize_database,
 )
-from pacsanini.utils import default_config_path
 
 
 @click.command(name="init")
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for initializing the database.",
-)
+@config_option
 @click.option(
     "--force-init",
     is_flag=True,
@@ -50,15 +42,7 @@ def init_cli(config: str, force_init: bool):
 
 
 @click.command(name="dump")
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for dumping the database.",
-)
+@config_option
 @click.option(
     "-o",
     "--output",

--- a/src/pacsanini/cli/net.py
+++ b/src/pacsanini/cli/net.py
@@ -9,7 +9,7 @@ from pynetdicom import debug_logger
 from sqlalchemy import create_engine, exc
 from sqlalchemy.orm import sessionmaker
 
-from pacsanini.cli.base import GroupCommand
+from pacsanini.cli.base import GroupCommand, config_option
 from pacsanini.config import PacsaniniConfig
 from pacsanini.db.crud import get_study_uids_to_move
 from pacsanini.models import QueryLevel
@@ -23,19 +23,11 @@ from pacsanini.net import (
     study_find2csv,
 )
 from pacsanini.net.c_find import patient_find2sql, study_find2sql
-from pacsanini.utils import default_config_path, is_db_uri, read_resources
+from pacsanini.utils import is_db_uri, read_resources
 
 
 @click.command(name="echo")
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
+@config_option
 @click.option("--debug", is_flag=True, help="If set, print debug messages.")
 def echo_cli(config: str, debug: bool):
     """Test your connection with an another DICOM node over a network."""
@@ -52,23 +44,15 @@ def echo_cli(config: str, debug: bool):
 
 
 @click.command(name="find")
+@config_option
 @click.option(
     "--create-tables",
     is_flag=True,
     default=False,
     help="If set, create the database tables before parsing results.",
 )
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
 @click.option("--debug", is_flag=True, help="If set, print debug messages.")
-def find_cli(create_tables: bool, config: str, debug: bool):
+def find_cli(config: str, create_tables: bool, debug: bool):
     """Emit C-FIND requests to the called node as specified by
     the config file. Results will be written to the output file
     specified by the "resources" setting in the configuration file.
@@ -116,15 +100,7 @@ def find_cli(create_tables: bool, config: str, debug: bool):
 
 
 @click.command(name="move", cls=GroupCommand)
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
+@config_option
 @click.option("--debug", is_flag=True, help="If set, print debug messages.")
 def move_cli(config: str, debug: bool):
     """Move the DICOM resources specified by the resources parameter in the
@@ -199,15 +175,7 @@ def move_cli(config: str, debug: bool):
 
 @click.command(name="send")
 @click.argument("dcmdir", type=click.Path(exists=True))
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
+@config_option
 @click.option("--debug", is_flag=True, help="If set, print debug messages.")
 def send_cli(dcmdir: str, config: str, debug: bool):
     """Send a DICOM or a DICOM directory by specifying the DCMDIR argument
@@ -232,15 +200,7 @@ def send_cli(dcmdir: str, config: str, debug: bool):
 
 
 @click.command(name="server")
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
+@config_option
 @click.option("--debug", is_flag=True, help="If set, print debug messages.")
 def server_cli(config: str, debug: bool):
     """Start a DICOM storescp server in the current process."""

--- a/src/pacsanini/cli/parse.py
+++ b/src/pacsanini/cli/parse.py
@@ -13,12 +13,11 @@ import yaml
 
 from click import Choice, ClickException, Path, command, confirm, echo, option, prompt
 
-from pacsanini.cli.base import GroupCommand, GroupOption
+from pacsanini.cli.base import GroupCommand, GroupOption, config_option
 from pacsanini.config import PacsaniniConfig
 from pacsanini.db import parse_dir2sql
 from pacsanini.errors import ConfigFormatError
 from pacsanini.io import parse_dir2csv, parse_dir2json
-from pacsanini.utils import default_config_path
 
 
 @command(name="parse", cls=GroupCommand)
@@ -32,17 +31,7 @@ from pacsanini.utils import default_config_path
     help_group="Input Options",
     help="The input directory to parse DICOM files.",
 )
-@option(
-    "-f",
-    "--config",
-    cls=GroupOption,
-    required=False,
-    type=Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help_group="Input Options",
-    help="The DICOM tags configuration file to use.",
-)
+@config_option
 @option(
     "-o",
     "--output",

--- a/src/pacsanini/cli/pipeline.py
+++ b/src/pacsanini/cli/pipeline.py
@@ -5,20 +5,12 @@
 """Expose the complete collection pipeline from the CLI."""
 import click
 
+from pacsanini.cli.base import config_option
 from pacsanini.pipeline import run_pacsanini_pipeline
-from pacsanini.utils import default_config_path
 
 
 @click.command(name="orchestrate")
-@click.option(
-    "-f",
-    "--config",
-    required=False,
-    type=click.Path(exists=True),
-    default=default_config_path(),
-    show_default=True,
-    help="The path to the configuration file to use for networking commands.",
-)
+@config_option
 @click.option(
     "-t",
     "--threads",

--- a/src/pacsanini/config.py
+++ b/src/pacsanini/config.py
@@ -20,9 +20,9 @@ from pacsanini.models import DicomNode, QueryLevel, StorageSortKey
 from pacsanini.parse import DicomTag, DicomTagGroup
 
 
-DEFAULT_SETTINGS_PATH = os.path.join(os.path.expanduser("~"), "pacsaninirc.yaml")
+DEFAULT_CONFIG_NAME = "pacsaninirc.yaml"
+DEFAULT_SETTINGS_PATH = os.path.join(os.path.expanduser("~"), DEFAULT_CONFIG_NAME)
 PACSANINI_CONF_ENVVAR = "PACSANINI_CONFIG"
-SETTINGS_PATH = os.environ.get(PACSANINI_CONF_ENVVAR, DEFAULT_SETTINGS_PATH)
 
 
 class EmailConfig(BaseModel):

--- a/src/pacsanini/utils.py
+++ b/src/pacsanini/utils.py
@@ -5,13 +5,18 @@
 """Simple utilities to facilitate the ingestion of resource values
 into the application.
 """
+import os
 import re
 
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 
-from pacsanini.config import SETTINGS_PATH
+from pacsanini.config import (
+    DEFAULT_CONFIG_NAME,
+    DEFAULT_SETTINGS_PATH,
+    PACSANINI_CONF_ENVVAR,
+)
 from pacsanini.errors import InvalidResourceFile
 from pacsanini.models import QueryLevel
 
@@ -81,8 +86,19 @@ def is_db_uri(uri: str) -> bool:
     return False
 
 
-def default_config_path() -> str:
-    """Returns the default configuration path set by an environment
-    variable or by using the default/hard-coded path.
+def default_config_path() -> Optional[str]:
+    """Returns the configuration file that should be used by default.
+    The choosing order is as such:
+    1. If set and if exists, use the PACSANINI_CONF_ENVVAR
+    2. If exists, use the DEFAULT_CONFIG_NAME
+    3. If exists, use the DEFAULT_SETTINGS_PATH
+    4. Otherwise, return None
     """
-    return SETTINGS_PATH
+    env_var = os.environ.get(PACSANINI_CONF_ENVVAR, "")
+    if env_var and os.path.exists(env_var):
+        return env_var
+    if os.path.exists(DEFAULT_CONFIG_NAME):
+        return DEFAULT_CONFIG_NAME
+    if os.path.exists(DEFAULT_SETTINGS_PATH):
+        return DEFAULT_SETTINGS_PATH
+    return None

--- a/tests/cli/base_test.py
+++ b/tests/cli/base_test.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
+"""Test that the base CLI methods and classes function correctly."""
+import os
+
+from unittest.mock import patch
+
+import pytest
+
+from click import command
+from click.testing import CliRunner
+
+from pacsanini.cli.base import config_option
+from pacsanini.config import PACSANINI_CONF_ENVVAR
+
+
+@pytest.fixture
+def dummy_func():
+    @command(name="dummy")
+    @config_option
+    def _dummy_func(config):
+        print(config)
+
+    return _dummy_func
+
+
+@pytest.mark.cli
+def test_config_option_with_explicit_non_existing_value(dummy_func):
+    """Test that the configuration file option raises an
+    error if the supplied file doesn't exist.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        res = runner.invoke(dummy_func, ["-f", "foobar"])
+        assert res.exception
+        assert res.exit_code != 0
+
+
+@pytest.mark.cli
+def test_config_option_with_explicit_value(dummy_func):
+    """Test that the configuration file option raises an
+    error if the supplied file doesn't exist.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("foobar", "w") as f:
+            f.write("")
+
+        res = runner.invoke(dummy_func, ["-f", "foobar"])
+        assert res.output.strip() == "foobar"
+        assert res.exit_code == 0
+
+
+@pytest.mark.cli
+@patch.dict(os.environ, {PACSANINI_CONF_ENVVAR: "foobar"})
+def test_config_option_with_implicit_value(dummy_func):
+    """Test that the configuration file option raises an
+    error if the supplied file doesn't exist.
+    """
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("foobar", "w") as f:
+            f.write("")
+
+        res = runner.invoke(dummy_func)
+        assert res.output.strip() == "foobar"
+        assert res.exit_code == 0

--- a/tests/db/crud_test.py
+++ b/tests/db/crud_test.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2019-2020, Therapixel SA.
+# All rights reserved.
+# This file is subject to the terms and conditions described in the
+# LICENSE file distributed in this package.
 """Test that CRUD methods function correctly."""
 from datetime import datetime, timedelta
 from typing import Tuple


### PR DESCRIPTION
In this PR, I defined the load order for the default configuration file when pacsanini is called from the CLI:
1. Use the file provided by the command line
2. Use the file defined by the envvar.
3. Use the file in the current directory.
4. Use the file in the home directory.
5. Use nothing and raise an error.

# What this PR does

Fixes #71 

## Submission checklist

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [x] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
