### PR TITLE
Updated tests to use orthanc as a storescp server

### DIFF
--- a/src/pacsanini/cli/base.py
+++ b/src/pacsanini/cli/base.py
@@ -54,8 +54,8 @@ def config_option(function: Callable) -> Callable:
 
     def validate_path(ctx, param, value):
         if not value:
-            config_path = default_config_path()
-            if not config_path:
+            value = default_config_path()
+            if not value:
                 msg = (
                     "No configuration file provided and no default"
                     " configuration file in the following locations:\n"
@@ -64,7 +64,7 @@ def config_option(function: Callable) -> Callable:
                     f" (3) Using the {DEFAULT_CONFIG_NAME} file in your homedir."
                 )
                 raise BadParameter(msg, ctx=ctx, param=param)
-            return config_path
+
         if not os.path.exists(value):
             raise BadParameter(f"'{value}' does not exist")
 

--- a/src/pacsanini/cli/net.py
+++ b/src/pacsanini/cli/net.py
@@ -168,7 +168,7 @@ def send_cli(dcmdir: str, config: PacsaniniConfig, debug: bool):
         debug_logger()
 
     results = send_dicom(
-        dcmdir, src_node=config.net.local_node, dest_node=config.net.dest_node
+        dcmdir, src_node=config.net.local_node, dest_node=config.net.called_node
     )
     for (path, status) in results:
         click.echo(f"{path},{'OK' if status.Status == 0 else 'FAILED'}")

--- a/tests/cli/base_test.py
+++ b/tests/cli/base_test.py
@@ -41,16 +41,16 @@ def test_config_option_with_explicit_non_existing_value(dummy_func):
 
 
 @pytest.mark.cli
-@patch.dict(os.environ, {PACSANINI_CONF_ENVVAR: "foobar"})
-def test_config_option_with_implicit_value(dummy_func):
+def test_config_option_with_implicit_value(dummy_func, pacsanini_orthanc_config):
     """Test that the configuration file option raises an
     error if the supplied file doesn't exist.
     """
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        with open("foobar", "w") as f:
-            f.write("")
+    with patch.dict(os.environ, {PACSANINI_CONF_ENVVAR: pacsanini_orthanc_config}):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("foobar", "w") as f:
+                f.write("")
 
-        res = runner.invoke(dummy_func)
-        assert res.output.strip() == "foobar"
-        assert res.exit_code == 0
+            res = runner.invoke(dummy_func, catch_exceptions=True)
+            assert "Config" in res.output
+            assert res.exit_code == 0

--- a/tests/net/c_echo_test.py
+++ b/tests/net/c_echo_test.py
@@ -5,62 +5,38 @@
 """Test the c_echo module and make sure that results are correctly obtained."""
 import pytest
 
-from pynetdicom import AE, ALL_TRANSFER_SYNTAXES, evt
-from pynetdicom.sop_class import (  # pylint: disable=no-name-in-module
-    VerificationSOPClass,
-)
-
+from pacsanini.config import PacsaniniConfig
 from pacsanini.net.c_echo import echo
 
 
-@pytest.fixture
-def echoscp(test_dest_node: dict):
-    """Simple echoscp server for testing purposes."""
-
-    def handle_cecho(event):
-        return 0x0000
-
-    ae = AE(ae_title=test_dest_node["aetitle"].encode())
-    ae.add_supported_context(VerificationSOPClass, ALL_TRANSFER_SYNTAXES)
-    server = None
-    try:
-        server = ae.start_server(
-            ("", test_dest_node["port"]),
-            evt_handlers=[(evt.EVT_C_ECHO, handle_cecho)],
-            block=False,
-        )
-        yield ae
-    finally:
-        if server is not None:
-            server.shutdown()
-
-
 @pytest.mark.net
-def test_c_echo_invalid_node(test_src_node: dict):
+def test_c_echo_invalid_node(config: PacsaniniConfig):
     """Test that if the destination node does not have correct
     information, the c_echo methods returns an error.
     """
+    test_src_node = config.net.local_node.dict()
+    del test_src_node["ip"]
     with pytest.raises(ValueError):
         echo(test_src_node, test_src_node)
 
 
 @pytest.mark.net
-def test_c_echo_unreachable_node(test_src_node: dict):
+def test_c_echo_unreachable_node(config: PacsaniniConfig):
     """Test that if the destination cannot be reached,
     a value of -1 is returned.
     """
-    unreachable_node = test_src_node.copy()
+    unreachable_node = config.net.local_node.dict()
     unreachable_node["ip"] = "www.localhost.com"
     unreachable_node["port"] = 11118
 
-    result = echo(test_src_node, unreachable_node)
+    result = echo(config.net.local_node, unreachable_node)
     assert result == -1
 
 
 @pytest.mark.net
-def test_c_echo(echoscp: AE, test_src_node: dict, test_dest_node: dict):
+def test_c_echo(config: PacsaniniConfig):
     """Test that sending a C-ECHO message to a functional
     DICOM node works correctly.
     """
-    result = echo(test_src_node, test_dest_node)
+    result = echo(config.net.local_node, config.net.called_node)
     assert result == 0

--- a/tests/net/conftest.py
+++ b/tests/net/conftest.py
@@ -3,108 +3,12 @@
 # This file is subject to the terms and conditions described in the
 # LICENSE file distributed in this package.
 """Provide fixtures for the net module testing suite."""
-import os
-
 import pytest
 
-from pydicom import Dataset, dcmread
-from pynetdicom import AE, ALL_TRANSFER_SYNTAXES, AllStoragePresentationContexts, evt
-from pynetdicom.events import Event
-from pynetdicom.sop_class import (  # pylint: disable=no-name-in-module
-    PatientRootQueryRetrieveInformationModelFind,
-    PatientRootQueryRetrieveInformationModelMove,
-    StudyRootQueryRetrieveInformationModelFind,
-    StudyRootQueryRetrieveInformationModelMove,
-    VerificationSOPClass,
-)
+from pacsanini.config import PacsaniniConfig
 
 
 @pytest.fixture
-def test_dest_node() -> dict:
-    """Return a DICOM node as a dict that can
-    be used to test the net functionalities.
-    """
-    return {"aetitle": "pacsanini_testing_server", "ip": "localhost", "port": 11112}
-
-
-@pytest.fixture
-def test_src_node() -> dict:
-    """Return a DICOM node as a dict that can
-    be used to initiate network queries.
-    """
-    return {"aetitle": "pacsanini_testing", "ip": 11114}
-
-
-@pytest.fixture
-def test_dicom_server(test_dest_node: dict, data_dir: str):
-    """Yield a mock DICOM server that can be used for testing."""
-    dicom_dir = os.path.join(data_dir, "dicom-files")
-
-    ae = AE(ae_title=test_dest_node["aetitle"])
-    ae.add_supported_context(VerificationSOPClass, ALL_TRANSFER_SYNTAXES)
-    for context in AllStoragePresentationContexts:
-        ae.add_supported_context(
-            context.abstract_syntax,
-            ALL_TRANSFER_SYNTAXES,
-            scp_role=True,
-            scu_role=False,
-        )
-
-    ae.add_supported_context(PatientRootQueryRetrieveInformationModelFind)
-    ae.add_supported_context(PatientRootQueryRetrieveInformationModelMove)
-    ae.add_supported_context(StudyRootQueryRetrieveInformationModelFind)
-    ae.add_supported_context(StudyRootQueryRetrieveInformationModelMove)
-
-    def handle_cfind(event: Event, data_dir: str):
-        model = event.request.AffectedSOPClassUID
-        if model not in ["PATIENT", "STUDY"]:
-            yield 0xC320, None
-            return
-
-        results = []
-        for root, _, files in os.walk(data_dir):
-            for name in files:
-                path = os.path.join(root, name)
-                dcm = dcmread(path, stop_before_pixels=True)
-
-                ds = Dataset()
-                is_ok = False
-                for key, value in event.identifier.items():
-                    tag_name = value.name
-                    if value.value:
-                        search_val = value.value
-                        if tag_name == "StudyDate" and "-" in search_val:
-                            lower_date, upper_date = (
-                                search_val.split("-")[0],
-                                search_val.split("-")[1],
-                            )
-                            is_ok = lower_date <= search_val <= upper_date
-                        else:
-                            is_ok = getattr(dcm, tag_name, None) == search_val
-                    setattr(ds, tag_name, getattr(dcm, tag_name, None))
-
-                if is_ok:
-                    results.append(ds)
-
-        for res in results:
-            yield 0xFF00, res
-
-    def handle_cmove(event: Event, data_dir: str):
-        yield "localhost", "11114", {"contexts": []}
-        yield 0
-        yield 0xFE00, None
-        return
-
-    handlers = [
-        (evt.EVT_C_FIND, handle_cfind, [data_dir]),
-        (evt.EVT_C_MOVE, handle_cmove, [data_dir]),
-    ]
-    server = None
-    try:
-        server = ae.start_server(
-            ("", test_dest_node["port"]), evt_handlers=handlers, block=False
-        )
-        yield ae
-    finally:
-        if server is not None:
-            server.shutdown()
+def config(pacsanini_orthanc_config: str):
+    """Return a pre-loaded configuration file."""
+    return PacsaniniConfig.from_yaml(pacsanini_orthanc_config)


### PR DESCRIPTION
# What this PR does

Fixes #92.

I've updated the tests so that all net-related tests use the orthanc server as a test pacs server. This also has the benefit of reducing the amount of code needed in the test suite.

To speed up tests a bit, I've also made it so that DICOM files sent to the server node are sent without pixel arrays.

## Submission checklist

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] I have updated the documentation.
- [x] I have updated relevant tests, if applicable.
- [ ] I have listed any additional dependencies that are needed for this change.

Thank you for contributing!
